### PR TITLE
Fix a bug where env vars containing = are mishandled

### DIFF
--- a/env.go
+++ b/env.go
@@ -21,7 +21,7 @@ func (e *Env) All() (map[string]interface{}, error) {
 	env := os.Environ()
 	m := make(map[string]interface{})
 	for _, pair := range env {
-		kv := strings.Split(pair, "=")
+		kv := strings.SplitN(pair, "=", 2)
 		if kv != nil && len(kv) >= 2 {
 			m[kv[0]] = kv[1]
 		}

--- a/env_test.go
+++ b/env_test.go
@@ -3,11 +3,12 @@ package factorcfg
 import (
 	"os"
 	"testing"
+
 	. "github.com/smartystreets/goconvey/convey"
 )
 
 func setupEnv() {
-	os.Setenv("FACTORCFG_A", "hey")
+	os.Setenv("FACTORCFG_A", "hey===stuff=things=")
 	os.Setenv("FACTORCFG_B", "5")
 	os.Setenv("FACTORCFG_C", "1.6")
 	os.Setenv("FACTORCFG_D", "hey,there,guy")

--- a/envfile_test.go
+++ b/envfile_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 const (
-	testEnvFile = `FACTORCFG_A=hey
+	testEnvFile = `FACTORCFG_A=hey===stuff=things=
 FACTORCFG_B=5
 FACTORCFG_C=1.6
 FACTORCFG_D=hey,there,guy

--- a/factorcfg_test.go
+++ b/factorcfg_test.go
@@ -17,7 +17,7 @@ type cfgTest struct {
 }
 
 var cfgExample = &cfgTest{
-	A: "hey",
+	A: "hey===stuff=things=",
 	B: 5,
 	C: 1.6,
 	D: []string{"hey", "there", "guy"},


### PR DESCRIPTION
If you have for example
A="one=two"

from a .env file A will be "one=two" as it should, from an actual env var  A will be "one".

This PR fixes it, and modifies one of your test cases to expose the bug.